### PR TITLE
Use custom MySQL port when connecting

### DIFF
--- a/mysql_statsd/thread_mysql.py
+++ b/mysql_statsd/thread_mysql.py
@@ -50,7 +50,7 @@ class ThreadMySQL(ThreadBase):
         return self.host, self.port, self.sleep_interval
 
     def setup_connection(self):
-        self.connection = mdb.connect(host=self.host, user=self.username, passwd=self.password)
+        self.connection = mdb.connect(host=self.host, user=self.username, port=self.port, passwd=self.password)
         return self.connection
 
     def stop(self):


### PR DESCRIPTION
Looks like the port was ingested... just never used when connecting.