### PR TITLE
Option to print metrics instead of sending to statsd.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,9 @@ Usage
       -h, --help            show this help message and exit
       -c FILE, --config FILE
                             Configuration file
-      -d, --debug           Debug mode
-      --stdout              Print metrics on stdout instead of sending to statsd.
+      -d, --debug           Prints statsd metrics next to sending them
+      --dry-run             Print the output that would be sent to statsd without
+                            actually sending data somewhere
       -f, --foreground      Dont fork main program
 
 At the moment there is also a `deamon

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ Usage
       -c FILE, --config FILE
                             Configuration file
       -d, --debug           Debug mode
+      --stdout              Print metrics on stdout instead of sending to statsd.
       -f, --foreground      Dont fork main program
 
 At the moment there is also a `deamon

--- a/mysql_statsd/thread_statsd.py
+++ b/mysql_statsd/thread_statsd.py
@@ -78,6 +78,12 @@ class ThreadStatsd(ThreadBase):
                 continue
 
 
+class ThreadFakeStatsd(ThreadStatsd):
+    """Prints metrics instead of sending them to statsd."""
+    def send_stat(self, item):
+        print item
+
+
 if __name__ == '__main__':
     # Run standalone to test this module, it will generate garbage
     from thread_manager import ThreadManager


### PR DESCRIPTION
A simple option --stdout for if you just want to see what the daemon is going to do without using nc or actually writing to statsd.

I didn't add any tests this time because it looked like it would just be mocking which object is constructed which doesn't seem that useful unless everything else is all very well covered.  Please let me know if you want me to add some.