### PR TITLE
Be more resillient in cases of mysql errors

### DIFF
--- a/mysql_statsd/mysql_statsd.py
+++ b/mysql_statsd/mysql_statsd.py
@@ -80,7 +80,18 @@ class MysqlStatsd():
 
         # Get thread manager
         tm = ThreadManager(threads=[mysql_thread, statsd_thread])
-        tm.run()
+
+        try:
+            tm.run()
+        except:
+            # Protects somewhat from needing to kill -9 if there is an exception
+            # within the thread manager by asking for a quit an joining.
+            try:
+                tm.stop_threads()
+            except:
+                pass
+
+            raise
 
     def get_config(self, config_file):
         cnf = ConfigParser()

--- a/mysql_statsd/thread_manager.py
+++ b/mysql_statsd/thread_manager.py
@@ -21,10 +21,16 @@ class ThreadManager():
         signal.signal(signal.SIGTERM, self.signal_handler)
 
     def run(self):
-        # Main loop
+        """Main loop."""
         self.start_threads()
         while not self.quit:
             time.sleep(1)
+
+            dead = [thread for thread in self.threads if not thread.is_alive()]
+            if dead and not self.quitting:
+                print("Thread {0!r} has stopped unexpectedly.".format(thread))
+                self.stop_threads()
+                return
 
     def start_threads(self):
         for t in self.threads:


### PR DESCRIPTION
We are using mysql-statsd to monitor a remote db which tends to fail every now and then because of unreliable internet.  This patch makes the daemon and the mysql thread more able to deal with these problems.  

This is a work in progress which we're currently trying out.  You should probably not merge this for a few days in case we find some problems with it.  I wanted to make the PR early so you can have some idea what I'm doing.

Specifically:

* manager: if one of the threads (including the main thread) crashes the daemon will terminate gracefully 

I did consider trying to make it restart but it seems like that should be more effectively done with monitoring tools (which will give better reporting) and in the mysql thread which will be more granular.

Also it would be more resource friendly to use some kind of event to detect the thread has crashed or if we're intentionally quitting but I couldn't work out how to do it.

* mysql: if there is a 2006 "gone away" error, we will close and reconnect.  

This is the most common problem when the connection isn't reliable but I expect I will find others which want a reconnect too.  I don't want to just reconnect by default to avoid spamming too many connections.

You can reproduce this problem by running `SET wait_timeout = 0` at some point.

* mysql: any other error will wait until a limit of consecutive query errors is reached before giving up

* mysql: reconnect errors must be consecutive before we'll give up.

This is backwards incompatible but seems more sensible than the current behaviour.

* mysql: the default is to terminate the thread when reaching the reconnect limit or the error limit.

Not sure if you want to add some configuration for this because this is backwards incompatible.  For errors it doesn't make any difference because previously the daemon will just hang after any exception.